### PR TITLE
[patch] add glg.RawString function for Custom Writer

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -14,6 +14,7 @@ func (n NetWorkLogger) Write(b []byte) (int, error) {
 	// http.Post("localhost:8080/log", "", bytes.NewReader(b))
 	http.Get("http://127.0.0.1:8080/log")
 	glg.Success("Requested")
+	glg.Infof("RawString is %s", glg.RawString(b))
 	return 1, nil
 }
 

--- a/glg_test.go
+++ b/glg_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 type ExitError int
@@ -2999,6 +3000,59 @@ func Test_blankFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := blankFormat(len(tt.vals)); got != tt.want {
 				t.Errorf("blankFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGlg_RawString(t *testing.T) {
+	tests := []struct {
+		name string
+		args []byte
+		want string
+	}{
+		{
+			name: "trim",
+			args: []byte(time.Now().Format(timeFormat) + "\t[" + INFO.String() + "]:\tHello Glg" + rc),
+			want: "Hello Glg",
+		},
+		{
+			name: "trim hard",
+			args: []byte(time.Now().Format(timeFormat) + "\t[" + INFO.String() + "]:\tHello Glg]:\tHello" + rc),
+			want: "Hello Glg]:\tHello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := New()
+			if got := g.RawString(tt.args); got != tt.want {
+				t.Errorf("Glg.RawString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRawString(t *testing.T) {
+	tests := []struct {
+		name string
+		args []byte
+		want string
+	}{
+		{
+			name: "trim",
+			args: []byte(time.Now().Format(timeFormat) + "\t[" + INFO.String() + "]:\tHello Glg" + rc),
+			want: "Hello Glg",
+		},
+		{
+			name: "trim hard",
+			args: []byte(time.Now().Format(timeFormat) + "\t[" + INFO.String() + "]:\tHello Glg]:\tHello" + rc),
+			want: "Hello Glg]:\tHello",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := glg.RawString(tt.args); got != tt.want {
+				t.Errorf("Glg.RawString() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Add RawString function

Usage is below

```go
type obj struct{}

func (n obj) Write(b []byte) (int, error) {
	glg.Infof("RawString is %s", glg.RawString(b)) // RawString is debug
	return len(b), nil
}
```
```go
glg.Get().AddLevelWriter(glg.DEBG, obj{}) 

glg.Debug("debug")
```

Signed-off-by: kpango <i.can.feel.gravity@gmail.com>